### PR TITLE
Event Join

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -5,7 +5,7 @@ class EventsController < ApplicationController
     @events = Event.all
   end
 
-  def show
+  def show  
   end
 
   def new

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -50,9 +50,17 @@ class EventsController < ApplicationController
     end
   end
 
+  def join
+    @event = Event.where(params[:join_code])
+  end
+
   private
     def set_event
-      @event = Event.find(params[:id])
+      if :id == 'join'
+        redirect_to /join/
+      else
+        @event = Event.find(params[:id])
+      end
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -64,28 +64,23 @@ class EventsController < ApplicationController
     end
   end
 
-  private
-    def set_event
-      if :id == 'join'
-        redirect_to /join/
-      else
-        @event = Event.find(params[:id])
-      end
-    end
+private
 
-    # Never trust parameters from the scary internet, only allow the white list through.
-    def event_params
-      params.require(:event).permit(:name, :description)
-    end
+  def set_event
+    @event = Event.find(params[:id])
+  end
 
-    def authenticate
-      unless can_view?
-        redirect_to root_path
-      end
-    end
+  # Never trust parameters from the scary internet, only allow the white list through.
+  def event_params
+    params.require(:event).permit(:name, :description)
+  end
 
-    def can_view?
-      (current_user.present? and @event.user == current_user) || 
-      (Event.find_by_join_code(cookies.permanent.encrypted[:join_cookie]).present?)
-    end
+  def authenticate
+    redirect_to root_path unless can_view?
+  end
+
+  def can_view?
+    (current_user.present? and @event.user == current_user) || 
+      (Event.find_by_join_code(cookies.permanent.encrypted[:join_cookie]) == @event)
+  end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -80,7 +80,7 @@ class EventsController < ApplicationController
   end
 
   def can_view?
-    (current_user.present? && @event.user == current_user) || 
+    (current_user.present? && @event.user == current_user) ||
       (Event.find_by_join_code(cookies.permanent.encrypted[:join_cookie]) == @event)
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -6,7 +6,7 @@ class EventsController < ApplicationController
     @events = Event.all
   end
 
-  def show  
+  def show
   end
 
   def new
@@ -64,7 +64,7 @@ class EventsController < ApplicationController
     end
   end
 
-private
+  private
 
   def set_event
     @event = Event.find(params[:id])
@@ -80,7 +80,7 @@ private
   end
 
   def can_view?
-    (current_user.present? and @event.user == current_user) || 
+    (current_user.present? && @event.user == current_user) || 
       (Event.find_by_join_code(cookies.permanent.encrypted[:join_cookie]) == @event)
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -25,7 +25,7 @@ class Event < ApplicationRecord
   before_create :set_join_code
 
   def avatar_image
-    # we currently have 5 default iamges
+    # we currently have 5 default images
     "events/#{(self.id % 4) + 1}.jpg"
   end
 

--- a/app/views/events/join.html.haml
+++ b/app/views/events/join.html.haml
@@ -1,0 +1,7 @@
+.container.container-custom
+  = form_tag '/events', method: 'join' do
+  = field_set_tag do
+  = label_tag :code, 'Event Code:'
+  = text_field_tag :code
+  = submit_tag 'Go'
+  

--- a/app/views/events/join.html.haml
+++ b/app/views/events/join.html.haml
@@ -1,7 +1,5 @@
 .container.container-custom
-  = form_tag '/events', method: 'join' do
-  = field_set_tag do
-  = label_tag :code, 'Event Code:'
-  = text_field_tag :code
-  = submit_tag 'Go'
-  
+  = form_for :events, :url => {:controller => 'events', :action => 'join'} do
+    = label_tag :join_tag, "Event Code:"
+    = text_field_tag :j
+    = button_tag 'Go' , class: 'join-button' , type: :submit

--- a/app/views/events/join.html.haml
+++ b/app/views/events/join.html.haml
@@ -1,5 +1,6 @@
 .container.container-custom
-  = form_for :events, :url => {:controller => 'events', :action => 'join'} do
-    = label_tag :join_tag, "Event Code:"
-    = text_field_tag :j
+  = form_for :events, :url => create_join_events_path do
+    = label_tag :join_code, "Event Code:"
+    = text_field_tag :join_code
     = button_tag 'Go' , class: 'join-button' , type: :submit
+

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -27,7 +27,7 @@
 
         %ul.nav.navbar-nav.pull-xs-right
           %li.nav-item
-            = link_to root_path, class: "nav-link" do
+            = link_to join_events_path, class: "nav-link" do
               %i.fa.fa-share
               Join an Event
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
   resources :users, only: [:show]
   root "home#index"
   get '/playlists/:id', to: 'playlist#show'
+  get '/join/', to: 'events#join'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   mount ActionCable.server => '/cable'
-  resources :events, except: [:index] do 
+  resources :events, except: [:index] do
     get 'join', on: :collection
     post 'create_join', on: :collection
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,11 @@
 Rails.application.routes.draw do
   mount ActionCable.server => '/cable'
-  resources :events, except: [:index]
+  resources :events, except: [:index] do 
+    get 'join', on: :collection
+    post 'create_join', on: :collection
+  end
   devise_for :users
   resources :users, only: [:show]
   root "home#index"
   get '/playlists/:id', to: 'playlist#show'
-  get '/join', to: 'events#join'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,5 @@ Rails.application.routes.draw do
   resources :users, only: [:show]
   root "home#index"
   get '/playlists/:id', to: 'playlist#show'
-  get '/join/', to: 'events#join'
+  get '/join', to: 'events#join'
 end


### PR DESCRIPTION
- Add the ability for guests to join an event use the event code.
- Add basic authentication to events.
- Save the join cookie encrypted so users don't have to rejoin