### PR TITLE
Enhance Event Owner Interaction & Authentication 

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -22,21 +22,7 @@ class EventsController < ApplicationController
     @event = Event.new(event_params)
     @event.user = current_user # the owner
 
-    pnator_on = params[:pnator_on] == 'on'
-    if pnator_on
-      target_energy = params[:pnator_energy].to_i / 100.to_f
-      target_danceability = params[:pnator_danceability].to_i / 100.to_f
-      target_popularity = params[:pnator_popularity].to_i / 100.to_f
-      target_speechiness = params[:pnator_speechiness].to_i / 100.to_f
-      target_happiness = params[:pnator_happiness].to_i / 100.to_f
-
-      @event.pnator_enabled = pnator_on
-      @event.pnator_danceability = target_danceability
-      @event.pnator_energy = target_energy
-      @event.pnator_popularity = target_popularity
-      @event.pnator_speechiness = target_speechiness
-      @event.pnator_happiness = target_happiness
-    end
+    pnator_setup
 
     respond_to do |format|
       if @event.save
@@ -50,8 +36,10 @@ class EventsController < ApplicationController
   end
 
   def update
+    pnator_setup
+
     respond_to do |format|
-      if @event.update(event_params)
+      if @event.save && @event.update(event_params)
         format.html { redirect_to @event, notice: 'Event was successfully updated.' }
         format.json { render :show, status: :ok, location: @event }
       else
@@ -94,6 +82,24 @@ class EventsController < ApplicationController
   end
 
   private
+
+  def pnator_setup
+    pnator_on = params[:pnator_on] == 'on'
+    if pnator_on
+      target_energy = params[:pnator_energy].to_i / 100.to_f
+      target_danceability = params[:pnator_danceability].to_i / 100.to_f
+      target_popularity = params[:pnator_popularity].to_i / 100.to_f
+      target_speechiness = params[:pnator_speechiness].to_i / 100.to_f
+      target_happiness = params[:pnator_happiness].to_i / 100.to_f
+
+      @event.pnator_enabled = pnator_on
+      @event.pnator_danceability = target_danceability
+      @event.pnator_energy = target_energy
+      @event.pnator_popularity = target_popularity
+      @event.pnator_speechiness = target_speechiness
+      @event.pnator_happiness = target_happiness
+    end
+  end
 
   def join_event_params
     if params.key?(:join_code)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class EventsController < ApplicationController
-  before_action :set_event, only: [:show, :edit, :update, :destroy, :start_playing]
+  before_action :set_event, only: [:show, :edit, :update, :destroy, :start_playing, :stop_playing, :create_new_playlist]
   before_action :authenticate, only: [:show, :edit]
   before_action :authenticate_owner, only: [:edit, :update]
 
@@ -81,6 +81,22 @@ class EventsController < ApplicationController
     end
   end
 
+  def stop_playing
+    if @event.update(currently_playing: false)
+      redirect_to @event, notice: 'Nifty! The playlist has stopped.'
+    else
+      redirect_to @event, error: 'An error occurred stopping the playlist.'
+    end
+  end
+
+  def create_new_playlist
+    if create_playlist(true)
+      redirect_to @event, notice: 'Slick! A new playlist was created.'
+    else
+      redirect_to @event, error: 'An error occurred creating the new playlist.'
+    end
+  end
+
   private
 
   def pnator_setup
@@ -117,8 +133,8 @@ class EventsController < ApplicationController
     @event.queue_next_song
   end
 
-  def create_playlist
-    return true if @event.spotify_playlist_id.present?
+  def create_playlist(force = false)
+    return true if @event.spotify_playlist_id.present? && !force
 
     playlist = @event.user.spotify.create_playlist!(@event.name)
     @event.update(spotify_playlist_id: playlist.id)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,6 +2,7 @@
 class EventsController < ApplicationController
   before_action :set_event, only: [:show, :edit, :update, :destroy, :start_playing]
   before_action :authenticate, only: [:show, :edit]
+  before_action :authenticate_owner, only: [:edit, :update]
 
   def index
     @events = Event.all
@@ -122,8 +123,16 @@ class EventsController < ApplicationController
     redirect_to root_path unless can_view?
   end
 
+  def authenticate_owner
+    redirect_to @event unless owns_event?
+  end
+
   def can_view?
     (current_user.present? && @event.user == current_user) ||
       (Event.find_by_join_code(cookies.permanent.encrypted[:join_cookie]) == @event)
+  end
+
+  def owns_event?
+    current_user.present? && @event.user == current_user
   end
 end

--- a/app/views/events/_actions.html.haml
+++ b/app/views/events/_actions.html.haml
@@ -1,10 +1,24 @@
 - if owner?(@event)
   .card-footer.text-muted
-    - if current_user.user_spotify_authenticated?
-      = link_to start_playing_event_path, method: :post, class: "btn btn-primary" do
-        %i.fa.fa-play
-        Play on Spotify
-    - else
+    - if !current_user.user_spotify_authenticated?
       = link_to '/auth/spotify', class: "btn btn-primary" do
         %i.fa.fa-spotify
         Sign in with Spotify
+    - else
+      - if @event.currently_playing
+        = link_to start_playing_event_path, method: :post, class: "btn btn-primary" do
+          %i.fa.fa-stop
+          Stop Playing on Spotify
+      - elsif !@event.currently_playing
+        = link_to start_playing_event_path, method: :post, class: "btn btn-primary" do
+          %i.fa.fa-play
+          Play on Spotify
+
+      - if @event.spotify_playlist_id.present?
+        = link_to start_playing_event_path, method: :post, class: "btn btn-primary" do
+          %i.fa.fa-th-list
+          Create new Playlist
+      - else
+        = link_to start_playing_event_path, method: :post, class: "btn btn-primary" do
+          %i.fa.fa-th-list
+          Create Playlist

--- a/app/views/events/_actions.html.haml
+++ b/app/views/events/_actions.html.haml
@@ -8,19 +8,19 @@
       = link_to stop_playing_event_path, method: :post, class: "btn btn-primary" do
         %i.fa.fa-stop
         Stop Playing on Spotify
-    - elsif !@event.currently_playing
+    - elsif !@event.currently_playing && @event.spotify_playlist_id.present?
       = link_to start_playing_event_path, method: :post, class: "btn btn-primary" do
         %i.fa.fa-play
         Play on Spotify
 
     - if @event.spotify_playlist_id.present?
       = link_to create_new_playlist_event_path, method: :post, class: "btn btn-primary" do
-        %i.fa.fa-th-list
-        Create new Playlist
+        %i.fa.fa-spotify
+        Create new Spotify Playlist
     - else
       = link_to create_new_playlist_event_path, method: :post, class: "btn btn-primary" do
-        %i.fa.fa-th-list
-        Create Playlist
+        %i.fa.fa-spotify
+        Create Spotify Playlist
 
   - if @event.pnator_enabled
     = link_to '#pnator', class: 'btn btn-info' do

--- a/app/views/events/_actions.html.haml
+++ b/app/views/events/_actions.html.haml
@@ -1,0 +1,10 @@
+- if owner?(@event)
+  .card-footer.text-muted
+    - if current_user.user_spotify_authenticated?
+      = link_to start_playing_event_path, method: :post, class: "btn btn-primary" do
+        %i.fa.fa-play
+        Play on Spotify
+    - else
+      = link_to '/auth/spotify', class: "btn btn-primary" do
+        %i.fa.fa-spotify
+        Sign in with Spotify

--- a/app/views/events/_actions.html.haml
+++ b/app/views/events/_actions.html.haml
@@ -5,7 +5,7 @@
       Sign in with Spotify
   - else
     - if @event.currently_playing
-      = link_to start_playing_event_path, method: :post, class: "btn btn-primary" do
+      = link_to stop_playing_event_path, method: :post, class: "btn btn-primary" do
         %i.fa.fa-stop
         Stop Playing on Spotify
     - elsif !@event.currently_playing
@@ -14,11 +14,11 @@
         Play on Spotify
 
     - if @event.spotify_playlist_id.present?
-      = link_to start_playing_event_path, method: :post, class: "btn btn-primary" do
+      = link_to create_new_playlist_event_path, method: :post, class: "btn btn-primary" do
         %i.fa.fa-th-list
         Create new Playlist
     - else
-      = link_to start_playing_event_path, method: :post, class: "btn btn-primary" do
+      = link_to create_new_playlist_event_path, method: :post, class: "btn btn-primary" do
         %i.fa.fa-th-list
         Create Playlist
 

--- a/app/views/events/_actions.html.haml
+++ b/app/views/events/_actions.html.haml
@@ -25,3 +25,4 @@
   - if @event.pnator_enabled
     = link_to '#pnator', class: 'btn btn-info' do
       %i.fa.fa-magic
+      Magic Playlist

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -45,16 +45,7 @@
           %p.card-text.lead
             = @event.description
 
-        - if owner?(@event)
-          .card-footer.text-muted
-            - if current_user.user_spotify_authenticated?
-              = link_to start_playing_event_path, method: :post, class: "btn btn-primary" do
-                %i.fa.fa-play
-                Play on Spotify
-            - else
-              = link_to '/auth/spotify', class: "btn btn-primary" do
-                %i.fa.fa-spotify
-                Sign in with Spotify
+        = render 'actions'
 
   .row
     .col-md-12.col-lg-8.offset-lg-2

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -36,10 +36,11 @@
           %h2.event__name
             = @event.name
 
-            %small
-              = link_to edit_event_path(@event), class: "event__edit" do
-                %i.fa.fa-pencil
-                Edit
+            - if owner?(@event)
+              %small
+                = link_to edit_event_path(@event), class: "event__edit" do
+                  %i.fa.fa-pencil
+                  Edit
 
         .card-block
           %p.card-text.lead

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
   # events management and joining
   resources :events, except: [:index] do
     post 'start_playing', on: :member
+    post 'stop_playing', on: :member
+    post 'create_new_playlist', on: :member
   end
 
   get 'join(/:join_code)' => 'events#join', :as => :join_events


### PR DESCRIPTION
- [x] Don't allow any user/guest to edit or update events (also hide from UI)
- [x] Break actions into their own view
- [ ] Add more actions to interact with Spotify for owners