### PR TITLE
Reduce delay time from 20 seconds to 5 seconds

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -134,7 +134,7 @@ class Event < ApplicationRecord
     # if there are not songs currently playing or played, queue up!
     return true unless song.present?
 
-    (song.queued_at + (song.duration / 1000).seconds) <= (Time.now.utc + 20.seconds)
+    (song.queued_at + (song.duration / 1000).seconds) <= (Time.now.utc + 5.seconds)
   end
 
   def spotify_playlist


### PR DESCRIPTION
Maybe we can eventually find a better way to fix the delays, but this is good for now. Maybe we can make this customizable on a per-event basis, but that might make it too complicated for the user.