### PR TITLE
Only show tutorial on a first visit

### DIFF
--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -116,8 +116,17 @@
             Cool, Got it!
 
 
-- if params[:is_guest]
+- if params[:is_guest] &&
   :javascript
     $(document).ready(function () {
-      $('#intro-modal').modal('show');
+      var visitedBefore = document.cookie.includes("VisitedBefore");
+
+      if(!visitedBefore) {  // First time visitor
+        $('#intro-modal').modal('show');
+      }
+
+      var expire = new Date();
+      expire = new Date(expire.getTime() + 7776000000);
+
+      document.cookie = "VisitedBefore=yes; expires=" + expire;
     });

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -116,7 +116,7 @@
             Cool, Got it!
 
 
-- if params[:is_guest] &&
+- if params[:is_guest]
   :javascript
     $(document).ready(function () {
       var visitedBefore = document.cookie.includes("VisitedBefore");


### PR DESCRIPTION
This was done before by assuming that the guest wouldn't attempt to join using the join code a second time (and would instead join with /event/{id}). With the custom join codes, the join code will likely be the way guests remember how to get to an event, so we should not show the tutorial every time.