### PR TITLE
(5 minutes) As a user I want the search to act as expected so that I don't accidentally add the wrong song

### DIFF
--- a/app/assets/javascripts/search.coffee
+++ b/app/assets/javascripts/search.coffee
@@ -12,6 +12,9 @@ class App.Search
     @searchSelector.keyup @handleSearch
     $(document).on 'click', @closeSelector, @reset
 
+    # Number of the current request to Spotify (counts up from 0 each time we send a request)
+    @requestNum = 0
+
   handleSearch: (e) =>
     # if the search box is empty, clear the results
     if e.currentTarget.value.length == 0
@@ -41,7 +44,12 @@ class App.Search
       market: 'US'
       limit: 5
 
+    @requestNum = @requestNum + 1
+    curRequestNum = @requestNum
+
     $.get('https://api.spotify.com/v1/search', data, ((data, status, jqXHR) =>
+      if(curRequestNum < @requestNum) # This isn't the most recent request
+        return
       @clearSearchResults()
       @addSearchResultEntry entry for entry in data.tracks.items
     ), 'json')


### PR DESCRIPTION
The order that responses would come in was inconsistent to the request order, which would cause old search results to overwrite more recent ones. This caused search to be very inaccurate/buggy.

This fixes that by tracking request numbers.

Why am I still doing user stories?